### PR TITLE
Fix README sample compile errors and regex escape

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -138,7 +138,9 @@ vcpkg install libbson
 
 ``` cpp
 #include <cstdio>
+#include <cstdlib>
 #include <iostream>
+#include <string>
 #include <huaweicloud/core/exception/Exceptions.h>
 #include <huaweicloud/core/Client.h>
 #include <huaweicloud/vpc/v2/VpcClient.h>
@@ -149,23 +151,15 @@ using namespace HuaweiCloud::Sdk::Core::Exception;
 
 int main(void)
 {   
-    std::string ak;
-    std::string sk;
-#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
-    ak = getenv("HUAWEICLOUD_SDK_AK");
-    sk = getenv("HUAWEICLOUD_SDK_SK");    
-#elif defined(linux) || defined(__linux) || defined(__linux__)
-    char* envVar; 
-    #define INIT_ENV_VAR(ID, NAME)               \
-    do {                                     \
-        if (envVar = secure_getenv(#NAME)) { \
-            ID = std::string(envVar);        \
-        }                                    \
-    } while (0)
-    INIT_ENV_VAR(ak, HUAWEICLOUD_SDK_AK);
-    INIT_ENV_VAR(sk, HUAWEICLOUD_SDK_SK);
-    #undef INIT_ENV_VAR
-#endif
+    const char* akEnv = std::getenv("HUAWEICLOUD_SDK_AK");
+    const char* skEnv = std::getenv("HUAWEICLOUD_SDK_SK");
+    if (akEnv == nullptr || skEnv == nullptr) {
+        std::cerr << "Missing environment variables: HUAWEICLOUD_SDK_AK/HUAWEICLOUD_SDK_SK"
+                  << std::endl;
+        return 1;
+    }
+    std::string ak(akEnv);
+    std::string sk(skEnv);
     // Initialize AK/SK module
     auto basicCredentials = std::make_unique<BasicCredentials>();
     basicCredentials->withAk(ak)
@@ -175,7 +169,7 @@ int main(void)
     // Initialize HTTP config
     HttpConfig httpConfig = HttpConfig();
     // Configure VpcClient instance
-    std::unique_ptr<Vpc::V2::VpcClient> vpcApi_v2 = Vpc::V2::VpcClient::newBuilder()
+    std::unique_ptr<Vpc::V2::VpcClient> vpcApi = Vpc::V2::VpcClient::newBuilder()
             .withCredentials(std::unique_ptr<Credentials>(basicCredentials.release()))
             .withHttpConfig(httpConfig)
             .withEndPoint("{your endpoint}")
@@ -379,7 +373,7 @@ globalCredentials->withAk(ak)
 
 ``` cpp
 // 初始化指定云服务的客户端 {Service}Client ，以初始化 VpcClient 为例
-std::unique_ptr<Vpc::V2::VpcClient> vpcApi_v2 = Vpc::V2::VpcClient::newBuilder()
+std::unique_ptr<Vpc::V2::VpcClient> vpcApi = Vpc::V2::VpcClient::newBuilder()
     .withCredentials(basicCredentials)
     .withHttpConfig(httpConfig)
     .withEndPoint(endpoint)
@@ -459,7 +453,7 @@ auto client = DevStarClient::newBuilder()
 Vpc::V2::Model::ListVpcsRequest listRequest;
 std::shared_ptr<Vpc::V2::Model::ListVpcsResponse> listRes = vpcApi->listVpcs(listRequest);
 std::string responseBody = listRes->getHttpBody();
-std::cout << stringValue << std::endl;
+std::cout << responseBody << std::endl;
 ```
 
 #### 4.1 异常处理 [:top:](#用户手册-top)
@@ -479,12 +473,12 @@ try {
     std::shared_ptr<Vpc::V2::Model::ListVpcsResponse> listRes = 
         vpcApi->listVpcs(listRequest);
     std::string responseBody = listRes->getHttpBody();
-    std::cout << stringValue << std::endl;
+    std::cout << responseBody << std::endl;
 } catch (HostUnreachableException& e) {
     std::cout << e.what() << std::endl;
 } catch (SslHandShakeException& e) {
     std::cout << e.what() << std::endl;
-} catch (RetryQutageException& e) {
+} catch (RetryOutageException& e) {
     std::cout << e.what() << std::endl;
 } catch (CallTimeoutException& e) {
     std::cout << e.what() << std::endl;
@@ -502,7 +496,7 @@ try {
 // 采用c++ std::async接口实现，以listVpcs接口为例
 #include <future>
 auto future = std::async(std::launch::async,
-                        &Vpc::V2::VpcClient::listVpcs, vpcApi, listRequest);
+                        &Vpc::V2::VpcClient::listVpcs, vpcApi.get(), listRequest);
 auto listResponse = future.get();
 ```
 
@@ -516,7 +510,7 @@ SDK 支持打印 Access 级别的访问日志，需要用户手动打开日志�
 
 ``` cpp
 // 初始化指定云服务的客户端 {Service}Client ，以初始化 VpcClient 为例
-std::unique_ptr<Vpc::V2::VpcClient> vpcApi_v2 = Vpc::V2::VpcClient::newBuilder()
+std::unique_ptr<Vpc::V2::VpcClient> vpcApi = Vpc::V2::VpcClient::newBuilder()
     .withCredentials(basicCredentials)
     .withHttpConfig(httpConfig)
     .withFileLog(R"(.\log.txt)", true)

--- a/core/include/huaweicloud/core/utils/Constants.h
+++ b/core/include/huaweicloud/core/utils/Constants.h
@@ -41,7 +41,8 @@ static const std::function<bool(const HuaweiCloud::Sdk::Core::RequestParams&)> D
         std::string endpoint = requestParams.getHost();
         std::string https_scheme = "https://";
         endpoint = endpoint.substr(0, endpoint.find(https_scheme)) + endpoint.substr(endpoint.find(https_scheme) + https_scheme.length());
-        std::regex re("(^[a-z][a-z0-9-]+(\.[a-z]{2,}-[a-z]+-\d{1,2})?\.(my)?(huaweicloud|myhwclouds).(com|cn))");
+        // Use a raw string to avoid compiler escape issues (e.g. "\d"), and match literal dots.
+        std::regex re(R"((^[a-z][a-z0-9-]+(\.[a-z]{2,}-[a-z]+-\d{1,2})?\.(my)?(huaweicloud|myhwclouds)\.(com|cn)))");
         return !std::regex_match(endpoint, re);
 };
 }


### PR DESCRIPTION
This PR fixes several issues reported in #7:

- README/README_CN: fix inconsistent client variable name (vpcApi), fix undefined `stringValue` usage in exception snippet, fix RetryOutageException typo, and make env var parsing portable via std::getenv.
- core Constants: use raw string for endpoint regex and fix `\d` escape + literal dot matching to avoid compiler escape warnings.